### PR TITLE
fix: install Playwright browsers in CI for E2E tests

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -66,7 +66,10 @@ jobs:
       
       - name: Install dependencies
         run: pnpm install
-      
+
+      - name: Install Playwright browsers
+        run: pnpm --dir example/test-fast-md5 exec playwright install --with-deps chromium
+
       - name: Run linting
         run: pnpm run lint
       


### PR DESCRIPTION
## Summary
- CI E2E tests fail with `browserType.launch: Executable doesn't exist` because Playwright browser binaries are not installed
- Add a `playwright install --with-deps chromium` step after dependency installation

## Changes
- `.github/workflows/npm-publish.yml`: add "Install Playwright browsers" step

## Test plan
- [x] `pnpm run test:unit` — 12 tests passed
- [x] `pnpm run test:e2e` — 24 tests passed
- [x] Pre-commit hook (`pnpm run test:hook`) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)